### PR TITLE
Changed py2.6 fetch url

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python 2.6
         run: sudo apt-get install -y python2.6 python2.6-dev
       - name: Install pip
-        run: curl https://bootstrap.pypa.io/2.6/get-pip.py -o get-pip.py && sudo python2.6 get-pip.py
+        run: curl https://bootstrap.pypa.io/pip/2.6/get-pip.py -o get-pip.py && sudo python2.6 get-pip.py
       - name: Install Python dependencies
         run: sudo pip install -r requirements-test-py26.txt && sudo pip install .
       - name: Run tests


### PR DESCRIPTION
Earlier url for fetching py2.6 https://bootstrap.pypa.io/2.6/get-pip.py
does not work anymore, changing it to
https://bootstrap.pypa.io/pip/2.6/get-pip.py

More info: https://github.com/release-engineering/pubtools-pyxis/runs/2053690848