### PR TITLE
Add entrypoint for removing signatures

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [report]
 show_missing = True
-fail_under = 90
+fail_under = 100
 exclude_lines =
     pragma: no cover
     if __name__ == .__main__.:

--- a/pubtools/_pyxis/pyxis_client.py
+++ b/pubtools/_pyxis/pyxis_client.py
@@ -198,3 +198,17 @@ class PyxisClient(object):
                 resp.raise_for_status()
                 all_resp.extend(resp.json()["data"])
         return all_resp
+
+    def delete_container_signatures(self, signature_ids):
+        """Delete signatures matching given fields.
+
+        Args:
+            signature_ids ([str])
+                Internal Pyxis signature IDs of signatures which should be removed.
+        """
+        delete_endpoint = "signatures/id/{id}"
+
+        for signature_id in signature_ids:
+            resp = self.pyxis_session.delete(delete_endpoint.format(id=signature_id))
+            if resp.status_code != 404:
+                resp.raise_for_status()

--- a/pubtools/_pyxis/pyxis_ops.py
+++ b/pubtools/_pyxis/pyxis_ops.py
@@ -95,6 +95,13 @@ GET_SIGNATURES_ARGS[("--reference",)] = {
     "type": str,
 }
 
+DELETE_SIGNATURES_ARGS = CMD_ARGS.copy()
+DELETE_SIGNATURES_ARGS[("--ids",)] = {
+    "help": "comma separated signature IDs to remove or json file when prefixed with @",
+    "required": True,
+    "type": str,
+}
+
 
 def setup_pyxis_client(args, ccache_file):
     """
@@ -275,3 +282,24 @@ def get_signatures_main(sysargs=None):
 
         json.dump(res, sys.stdout, sort_keys=True, indent=4, separators=(",", ": "))
         return res
+
+
+def delete_signatures_main(sysargs=None):
+    """
+    Entrypoint for removing existing signatures.
+
+    Returns:
+        list: Signatures which were deleted.
+    """
+    parser = setup_arg_parser(DELETE_SIGNATURES_ARGS)
+    if sysargs:
+        args = parser.parse_args(sysargs[1:])
+    else:
+        args = parser.parse_args()  # pragma: no cover"
+
+    if args.ids:
+        signature_ids = deserialize_list_from_arg(args.ids, csv_input=True)
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        pyxis_client = setup_pyxis_client(args, tmpfile.name)
+        pyxis_client.delete_container_signatures(signature_ids)

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,8 @@ setup(
             "pubtools-pyxis-get-operator-indices = pubtools._pyxis.pyxis_ops:get_operator_indices_main",
             "pubtools-pyxis-get-repo-metadata = pubtools._pyxis.pyxis_ops:get_repo_metadata_main",
             "pubtools-pyxis-upload-signatures = pubtools._pyxis.pyxis_ops:upload_signatures_main",
-            "pubtools-pyxis-get-signatures = pubtools._pyxis.pyxis_ops:get_signatures_main"
+            "pubtools-pyxis-get-signatures = pubtools._pyxis.pyxis_ops:get_signatures_main",
+            "pubtools-pyxis-delete-signatures = pubtools._pyxis.pyxis_ops:delete_signatures_main"
         ]
     },
     include_package_data=True,

--- a/tests/test_pyxis_ops.py
+++ b/tests/test_pyxis_ops.py
@@ -753,3 +753,50 @@ def test_get_signatures_manifests_file(capsys):
         pyxis_ops.get_signatures_main(args)
     out, _ = capsys.readouterr()
     assert out == expected
+
+
+def test_delete_signatures(hostname):
+    ids = "g2g2g2g2,h3h3h3h3"
+    args = [
+        "dummy",
+        "--pyxis-server",
+        hostname,
+        "--ids",
+        ids,
+        "--pyxis-ssl-crtfile",
+        "/root/name.crt",
+        "--pyxis-ssl-keyfile",
+        "/root/name.key",
+    ]
+
+    with requests_mock.Mocker() as m:
+        m.delete("{0}v1/signatures/id/{1}".format(hostname, "g2g2g2g2"))
+        m.delete("{0}v1/signatures/id/{1}".format(hostname, "h3h3h3h3"))
+
+        pyxis_ops.delete_signatures_main(args)
+
+        assert len(m.request_history) == 2
+        assert m.request_history[0].url == "{0}v1/signatures/id/{1}".format(
+            hostname, "g2g2g2g2"
+        )
+        assert m.request_history[1].url == "{0}v1/signatures/id/{1}".format(
+            hostname, "h3h3h3h3"
+        )
+
+
+def test_delete_signatures_error(capsys, hostname):
+    no_filter_args = [
+        "dummy",
+        "--pyxis-server",
+        hostname,
+        "--pyxis-ssl-crtfile",
+        "/root/name.crt",
+        "--pyxis-ssl-keyfile",
+        "/root/name.key",
+    ]
+
+    with pytest.raises(SystemExit) as system_error:
+        pyxis_ops.delete_signatures_main(no_filter_args)
+
+    assert system_error.type == SystemExit
+    assert system_error.value.code == 2


### PR DESCRIPTION
Entrypoint works similiarly as entrypoint for getting signatures,
except it removes all the found results.