### PR TITLE
Switch from bulk to parallel uploads [CLOUDDST-7784]

### DIFF
--- a/docs/source/ops_helpers.rst
+++ b/docs/source/ops_helpers.rst
@@ -10,5 +10,4 @@ Main entrypoint functions
 
 .. autofunction:: setup_pyxis_client
 .. autofunction:: deserialize_list_from_arg
-.. autofunction:: serialize_to_json
 .. autofunction:: serialize_to_csv_from_list

--- a/docs/source/pyxis_client.rst
+++ b/docs/source/pyxis_client.rst
@@ -11,7 +11,8 @@ Class for performing actual Pyxis queries and handling related logic.
    .. automethod:: get_operator_indices
    .. automethod:: get_repository_metadata
    .. automethod:: upload_signatures
-   .. automethod:: _parse_response
+   .. automethod:: _do_parallel_requests
+   .. automethod:: _handle_json_response
    .. automethod:: get_container_signatures
    .. automethod:: _get_items_from_all_pages
    .. automethod:: delete_container_signatures

--- a/pubtools/_pyxis/constants.py
+++ b/pubtools/_pyxis/constants.py
@@ -1,0 +1,5 @@
+__all__ = ["DEFAULT_REQUEST_THREADS_LIMIT"]
+
+
+DEFAULT_REQUEST_THREADS_LIMIT = 16
+"Maximum number of threads to use for parallel requests."

--- a/pubtools/_pyxis/pyxis_authentication.py
+++ b/pubtools/_pyxis/pyxis_authentication.py
@@ -96,7 +96,11 @@ class PyxisKrbAuth(PyxisAuth):
                 ).wait()
                 os.environ["KRB5CCNAME"] = self.ccache_file
 
-        return HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        # preemptive auth is forced to speed up parallel requests
+        return HTTPKerberosAuth(
+            mutual_authentication=OPTIONAL,
+            force_preemptive=True,
+        )
 
     def apply_to_session(self, pyxis_session):
         """Set up PyxisSession with Kerberos auth.

--- a/pubtools/_pyxis/pyxis_client.py
+++ b/pubtools/_pyxis/pyxis_client.py
@@ -54,7 +54,10 @@ class PyxisClient(object):
     @property
     def pyxis_session(self):
         """
-        TODO: docs
+        Return a thread-local session for Pyxis requests.
+
+        If a session did not exist for current thread, it is initialized and
+        cached.
         """
         if not hasattr(self.thread_local, "pyxis_session"):
             self.thread_local.pyxis_session = self._make_session()
@@ -145,7 +148,24 @@ class PyxisClient(object):
 
     def _do_parallel_requests(self, make_request, data_items):
         """
-        TODO: docs
+        Call given function with given data items in parallel, collect responses.
+
+        Args:
+            make_request (function): a function that does the actual request.
+                Must accept a single argument: a data item.
+                Must return a `requests.models.Response` object.
+            data_items (list): a list of arbitrary objects to be passed
+                individually to `make_request()`.
+
+        The number of parallel requests is defined by `THREADS_LIMIT` and of
+        course the number of actually available threads.
+
+        If a response fails consistently (see `PyxisSession` for retry policy),
+        the execution is terminated and an informative error is raised.
+        See `PyxisClient._handle_json_response()` for details.
+
+        Returns:
+            list(dict): list of dictionaries extracted from responses.
         """
         with Executors.thread_pool(max_workers=THREADS_LIMIT).with_map(
             self._parse_response

--- a/pubtools/_pyxis/pyxis_client.py
+++ b/pubtools/_pyxis/pyxis_client.py
@@ -168,13 +168,13 @@ class PyxisClient(object):
             list(dict): list of dictionaries extracted from responses.
         """
         with Executors.thread_pool(max_workers=THREADS_LIMIT).with_map(
-            self._parse_response
+            self._handle_json_response
         ) as executor:
             futures = [executor.submit(make_request, data) for data in data_items]
 
             return [f.result() for f in as_completed(futures)]
 
-    def _parse_response(self, response):
+    def _handle_json_response(self, response):
         """
         Get JSON from given response or raise an informative exception.
 

--- a/pubtools/_pyxis/pyxis_ops.py
+++ b/pubtools/_pyxis/pyxis_ops.py
@@ -216,7 +216,7 @@ def upload_signatures_main(sysargs=None):
     if sysargs:
         args = parser.parse_args(sysargs[1:])
     else:
-        args = parser.parse_args()  # pragma: no cover"
+        args = parser.parse_args()
 
     signatures_json = serialize_to_json(deserialize_list_from_arg(args.signatures))
 

--- a/pubtools/_pyxis/pyxis_ops.py
+++ b/pubtools/_pyxis/pyxis_ops.py
@@ -2,6 +2,7 @@ import json
 import sys
 import tempfile
 
+from .constants import DEFAULT_REQUEST_THREADS_LIMIT
 from .pyxis_authentication import PyxisKrbAuth, PyxisSSLAuth
 from .pyxis_client import PyxisClient
 from .utils import setup_arg_parser
@@ -81,6 +82,12 @@ UPLOAD_SIGNATURES_ARGS[("--signatures",)] = {
     " with JSON, e.g. --signatures=@/tmp/filename.json",
     "required": True,
     "type": str,
+}
+UPLOAD_SIGNATURES_ARGS[("--request-threads",)] = {
+    "help": "Maximum number of threads to use for parallel requests",
+    "required": False,
+    "default": DEFAULT_REQUEST_THREADS_LIMIT,
+    "type": int,
 }
 
 GET_SIGNATURES_ARGS = CMD_ARGS.copy()

--- a/pubtools/_pyxis/pyxis_ops.py
+++ b/pubtools/_pyxis/pyxis_ops.py
@@ -216,9 +216,9 @@ def upload_signatures_main(sysargs=None):
     if sysargs:
         args = parser.parse_args(sysargs[1:])
     else:
-        args = parser.parse_args()
+        args = parser.parse_args()  # pragma: no cover
 
-    signatures_json = serialize_to_json(deserialize_list_from_arg(args.signatures))
+    signatures_json = deserialize_list_from_arg(args.signatures)
 
     with tempfile.NamedTemporaryFile() as tmpfile:
         pyxis_client = setup_pyxis_client(args, tmpfile.name)
@@ -252,11 +252,6 @@ def deserialize_list_from_arg(value, csv_input=False):
     with open(filename, "r") as f:
         # all file content is returned as list
         return json.load(f)
-
-
-def serialize_to_json(list_value):
-    """Convert any python list to json."""
-    return json.dumps(list_value)
 
 
 def serialize_to_csv_from_list(list_value):

--- a/requirements-test-py26.txt
+++ b/requirements-test-py26.txt
@@ -5,3 +5,9 @@ cryptography==2.1.4
 urllib3==1.23
 requests==2.18.4
 requests-kerberos==0.11.0
+
+# backport of concurrent.futures for Python 2.x.
+# do NOT install this under Python 3.x.
+#   Note: this is already in requirements.txt but Py2.6 has a special workflow
+#   in Github.  We just copy the dependency here to avoid touching that code.
+futures; python_version < '2.7'

--- a/requirements-test-py26.txt
+++ b/requirements-test-py26.txt
@@ -10,4 +10,4 @@ requests-kerberos==0.11.0
 # do NOT install this under Python 3.x.
 #   Note: this is already in requirements.txt but Py2.6 has a special workflow
 #   in Github.  We just copy the dependency here to avoid touching that code.
-futures; python_version < '2.7'
+futures; python_version < "3"

--- a/requirements-test-py26.txt
+++ b/requirements-test-py26.txt
@@ -5,9 +5,8 @@ cryptography==2.1.4
 urllib3==1.23
 requests==2.18.4
 requests-kerberos==0.11.0
+more-executors>=2.3.0
 
 # backport of concurrent.futures for Python 2.x.
 # do NOT install this under Python 3.x.
-#   Note: this is already in requirements.txt but Py2.6 has a special workflow
-#   in Github.  We just copy the dependency here to avoid touching that code.
 futures; python_version < "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 setuptools
+more-executors>=2.3.0
 requests
 requests-kerberos

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ setuptools
 more-executors>=2.3.0
 requests
 requests-kerberos
+
+# backport of concurrent.futures for Python 2.x.
+# do NOT install this under Python 3.x.
+futures; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ requests-kerberos
 
 # backport of concurrent.futures for Python 2.x.
 # do NOT install this under Python 3.x.
-futures; python_version < '2.7'
+futures; python_version < "3"

--- a/tests/test_pyxis_authentication.py
+++ b/tests/test_pyxis_authentication.py
@@ -3,7 +3,6 @@ import os
 import mock
 
 from pubtools._pyxis import pyxis_authentication, pyxis_session
-from tests.utils import urljoin
 
 
 def test_ssl_authentication(hostname):

--- a/tests/test_pyxis_authentication.py
+++ b/tests/test_pyxis_authentication.py
@@ -3,9 +3,10 @@ import os
 import mock
 
 from pubtools._pyxis import pyxis_authentication, pyxis_session
+from tests.utils import urljoin
 
 
-def test_ssl_authentication():
+def test_ssl_authentication(hostname):
     crt_path = "/root/name.crt"
     key_path = "/root/name.key"
 
@@ -13,14 +14,14 @@ def test_ssl_authentication():
     assert ssl_auth.crt_path == crt_path
     assert ssl_auth.key_path == key_path
 
-    my_pyxis_session = pyxis_session.PyxisSession("https://pyxis-prod-url/")
+    my_pyxis_session = pyxis_session.PyxisSession(hostname)
     ssl_auth.apply_to_session(my_pyxis_session)
     assert my_pyxis_session.session.cert == (crt_path, key_path)
 
 
-def test_krb_auth_init():
+def test_krb_auth_init(hostname):
     krb_princ = "name@REDHAT.COM"
-    service = "https://pyxis-prod-url/"
+    service = hostname
     ktfile = "/root/file.keytab"
 
     krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, ktfile)
@@ -31,9 +32,9 @@ def test_krb_auth_init():
 
 @mock.patch.dict("os.environ", {"something": "here"})
 @mock.patch("pubtools._pyxis.pyxis_authentication.subprocess.Popen")
-def test_krb_auth_use_keytab(mock_popen):
+def test_krb_auth_use_keytab(mock_popen, hostname):
     krb_princ = "name@REDHAT.COM"
-    service = "https://pyxis-prod-url/"
+    service = hostname
     ktfile = "/root/file.keytab"
 
     krb_auth = pyxis_authentication.PyxisKrbAuth(
@@ -66,9 +67,9 @@ def test_krb_auth_use_keytab(mock_popen):
 
 @mock.patch.dict("os.environ", {"something": "here"})
 @mock.patch("pubtools._pyxis.pyxis_authentication.subprocess.Popen")
-def test_krb_auth_use_default_keytab(mock_popen):
+def test_krb_auth_use_default_keytab(mock_popen, hostname):
     krb_princ = "name@REDHAT.COM"
-    service = "https://pyxis-prod-url/"
+    service = hostname
 
     krb_auth = pyxis_authentication.PyxisKrbAuth(
         krb_princ, service, ccache_file="/tmp/tempfile"
@@ -92,9 +93,9 @@ def test_krb_auth_use_default_keytab(mock_popen):
 
 @mock.patch.dict("os.environ", {"something": "here"})
 @mock.patch("pubtools._pyxis.pyxis_authentication.subprocess.Popen")
-def test_krb_auth_skip_init(mock_popen):
+def test_krb_auth_skip_init(mock_popen, hostname):
     krb_princ = "name@REDHAT.COM"
-    service = "https://pyxis-prod-url/"
+    service = hostname
 
     krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service)
     mock_wait = mock.MagicMock()
@@ -110,12 +111,12 @@ def test_krb_auth_skip_init(mock_popen):
 
 
 @mock.patch("pubtools._pyxis.pyxis_authentication.PyxisKrbAuth._krb_auth")
-def test_krb_apply_to_session(mock_krb_auth):
+def test_krb_apply_to_session(mock_krb_auth, hostname):
     krb_princ = "name@REDHAT.COM"
-    service = "https://pyxis-prod-url/"
+    service = hostname
     ktfile = "/root/file.keytab"
 
     krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, ktfile)
-    my_pyxis_session = pyxis_session.PyxisSession("https://pyxis-prod-url/")
+    my_pyxis_session = pyxis_session.PyxisSession(hostname)
     krb_auth.apply_to_session(my_pyxis_session)
     assert isinstance(my_pyxis_session.session.auth, mock.MagicMock)

--- a/tests/test_pyxis_client.py
+++ b/tests/test_pyxis_client.py
@@ -6,14 +6,13 @@ import requests
 import requests_mock
 
 from pubtools._pyxis import pyxis_client, pyxis_authentication
-from tests.utils import load_data
+from tests.utils import load_data, urljoin
 
 # flake8: noqa: W503
 
 
 @mock.patch("pubtools._pyxis.pyxis_client.PyxisSession")
-def test_client_init(mock_session):
-    hostname = "https://pyxis-prod-url/"
+def test_client_init(mock_session, hostname):
 
     pyxis_client.PyxisClient(hostname, 5, None, 3, True)
     mock_session.assert_called_once_with(
@@ -21,8 +20,7 @@ def test_client_init(mock_session):
     )
 
 
-def test_client_init_set_auth():
-    hostname = "https://pyxis-prod-url/"
+def test_client_init_set_auth(hostname):
     crt_path = "/root/name.crt"
     key_path = "/root/name.key"
     auth = pyxis_authentication.PyxisSSLAuth(crt_path, key_path)
@@ -31,8 +29,7 @@ def test_client_init_set_auth():
     my_client.pyxis_session.session.cert == (crt_path, key_path)
 
 
-def test_get_operator_indices():
-    hostname = "https://pyxis-prod-url/"
+def test_get_operator_indices(hostname):
     data = [
         {"path": "registry.io/index-image:4.5", "other": "stuff"},
         {"path": "registry.io/index-image:4.6", "other2": "stuff2"},
@@ -52,8 +49,7 @@ def test_get_operator_indices():
         assert res == data
 
 
-def test_get_repository_metadata():
-    hostname = "https://pyxis-prod-url/"
+def test_get_repository_metadata(hostname):
     data = {"metadata": "value", "metadata2": "value2"}
     repo_name = "some-repo/name"
     registry = "registry.access.redhat.com"
@@ -71,8 +67,7 @@ def test_get_repository_metadata():
         assert res == data
 
 
-def test_get_repository_metadata_partner_registry():
-    hostname = "https://pyxis-prod-url/"
+def test_get_repository_metadata_partner_registry(hostname):
     data = {"metadata": "value", "metadata2": "value2"}
     repo_name = "some-repo/name"
     internal_registry = "registry.access.redhat.com"
@@ -98,8 +93,7 @@ def test_get_repository_metadata_partner_registry():
         assert res == data
 
 
-def test_get_repository_metadata_only_internal():
-    hostname = "https://pyxis-prod-url/"
+def test_get_repository_metadata_only_internal(hostname):
     data = {"metadata": "value", "metadata2": "value2"}
     repo_name = "some-repo/name"
     registry = "registry.access.redhat.com"
@@ -117,8 +111,7 @@ def test_get_repository_metadata_only_internal():
         assert res == data
 
 
-def test_get_repository_metadata_only_partner():
-    hostname = "https://pyxis-prod-url/"
+def test_get_repository_metadata_only_partner(hostname):
     data = {"metadata": "value", "metadata2": "value2"}
     repo_name = "some-repo/name"
     registry = "registry.connect.redhat.com"
@@ -136,8 +129,7 @@ def test_get_repository_metadata_only_partner():
         assert res == data
 
 
-def test_get_repository_metadata_custom_registry():
-    hostname = "https://pyxis-prod-url/"
+def test_get_repository_metadata_custom_registry(hostname):
     data = {"metadata": "value", "metadata2": "value2"}
     repo_name = "some-repo/name"
     registry = "some.registry.com"
@@ -212,19 +204,21 @@ def test_delete_container_signatures_success(hostname):
     ids = ["g1g1g1g1", "h2h2h2h2"]
 
     with requests_mock.Mocker() as m:
-        m.delete("https://pyxis-prod-url/v1/signatures/id/g1g1g1g1")
-        m.delete("https://pyxis-prod-url/v1/signatures/id/h2h2h2h2")
+        m.delete(urljoin(hostname, "/v1/signatures/id/g1g1g1g1"))
+        m.delete(urljoin(hostname, "/v1/signatures/id/h2h2h2h2"))
 
         my_client = pyxis_client.PyxisClient(hostname, 5, None, 3, True)
         my_client.delete_container_signatures(ids)
         assert len(m.request_history) == 2
         assert (
-            m.request_history[0].url
-            == "https://pyxis-prod-url/v1/signatures/id/g1g1g1g1"
+            m.request_history[0].url == urljoin(
+                hostname, "/v1/signatures/id/g1g1g1g1"
+            )
         )
         assert (
-            m.request_history[1].url
-            == "https://pyxis-prod-url/v1/signatures/id/h2h2h2h2"
+            m.request_history[1].url == urljoin(
+                hostname, "/v1/signatures/id/h2h2h2h2"
+            )
         )
 
 
@@ -232,19 +226,21 @@ def test_delete_container_signatures_tolerate_404(hostname):
     ids = ["g1g1g1g1", "h2h2h2h2"]
 
     with requests_mock.Mocker() as m:
-        m.delete("https://pyxis-prod-url/v1/signatures/id/g1g1g1g1", status_code=404)
-        m.delete("https://pyxis-prod-url/v1/signatures/id/h2h2h2h2")
+        m.delete(urljoin(hostname, "/v1/signatures/id/g1g1g1g1"), status_code=404)
+        m.delete(urljoin(hostname, "/v1/signatures/id/h2h2h2h2"))
 
         my_client = pyxis_client.PyxisClient(hostname, 5, None, 3, True)
         my_client.delete_container_signatures(ids)
         assert len(m.request_history) == 2
         assert (
-            m.request_history[0].url
-            == "https://pyxis-prod-url/v1/signatures/id/g1g1g1g1"
+            m.request_history[0].url == urljoin(
+                hostname, "/v1/signatures/id/g1g1g1g1"
+            )
         )
         assert (
-            m.request_history[1].url
-            == "https://pyxis-prod-url/v1/signatures/id/h2h2h2h2"
+            m.request_history[1].url == urljoin(
+                hostname, "/v1/signatures/id/h2h2h2h2"
+            )
         )
 
 
@@ -252,14 +248,15 @@ def test_delete_container_signatures_server_error(hostname):
     ids = ["g1g1g1g1", "h2h2h2h2"]
 
     with requests_mock.Mocker() as m:
-        m.delete("https://pyxis-prod-url/v1/signatures/id/g1g1g1g1", status_code=500)
-        m.delete("https://pyxis-prod-url/v1/signatures/id/h2h2h2h2")
+        m.delete(urljoin(hostname, "/v1/signatures/id/g1g1g1g1"), status_code=500)
+        m.delete(urljoin(hostname, "/v1/signatures/id/h2h2h2h2"))
 
         my_client = pyxis_client.PyxisClient(hostname, 5, None, 3, True)
         with pytest.raises(requests.exceptions.HTTPError, match="500 Server Error.*"):
             my_client.delete_container_signatures(ids)
         assert len(m.request_history) == 1
         assert (
-            m.request_history[0].url
-            == "https://pyxis-prod-url/v1/signatures/id/g1g1g1g1"
+            m.request_history[0].url == urljoin(
+                hostname, "/v1/signatures/id/g1g1g1g1"
+            )
         )

--- a/tests/test_pyxis_session.py
+++ b/tests/test_pyxis_session.py
@@ -1,11 +1,11 @@
 import mock
 
 from pubtools._pyxis import pyxis_session
+from tests.utils import urljoin
 
 
 @mock.patch("pubtools._pyxis.pyxis_session.requests.Session")
-def test_session_init(mock_session):
-    hostname = "https://pyxis-prod-url/"
+def test_session_init(mock_session, hostname):
     mock_mount = mock.MagicMock()
     mock_session.return_value.mount = mock_mount
 
@@ -25,8 +25,7 @@ def test_api_url():
 
 
 @mock.patch("pubtools._pyxis.pyxis_session.requests.Session")
-def test_rest_methods(mock_session):
-    hostname = "https://pyxis-prod-url/"
+def test_rest_methods(mock_session, hostname):
     mock_get = mock.MagicMock()
     mock_post = mock.MagicMock()
     mock_put = mock.MagicMock()
@@ -43,17 +42,17 @@ def test_rest_methods(mock_session):
     my_session = pyxis_session.PyxisSession(hostname)
     my_session.post("add-item", data={"param2": "value2"})
     mock_post.assert_called_once_with(
-        hostname + "v1/add-item", data={"param2": "value2"}
+        urljoin(hostname, "v1/add-item"), data={"param2": "value2"}
     )
 
     my_session = pyxis_session.PyxisSession(hostname)
     my_session.put("edit-item", data={"param3": "value3"})
     mock_put.assert_called_once_with(
-        hostname + "v1/edit-item", data={"param3": "value3"}
+        urljoin(hostname, "v1/edit-item"), data={"param3": "value3"}
     )
 
     my_session = pyxis_session.PyxisSession(hostname)
     my_session.delete("rm-item", params={"param4": "value4"})
     mock_delete.assert_called_once_with(
-        hostname + "v1/rm-item", params={"param4": "value4"}
+        urljoin(hostname, "v1/rm-item"), params={"param4": "value4"}
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,9 @@ except ImportError:
     from urlparse import urljoin
 
 
+__all__ = ["urljoin", "load_data", "load_response"]
+
+
 def load_data(filename):
     with open("tests/data/{0}.json".format(filename)) as f:
         return f.read()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,9 @@
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+
 def load_data(filename):
     with open("tests/data/{0}.json".format(filename)) as f:
         return f.read()


### PR DESCRIPTION
Stop using bulk mode and start uploading signatures individually, so that the library does not break once the deprecated functionality is removed from Pyxis.