### PR TITLE
Fix building under Python 2.6

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include README.rst
 include LICENSE
 recursive-include docs *.rst conf.py Makefile
 recursive-include pubtools_pyxis *.py
-include requirements.txt
+include requirements*.txt

--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,0 +1,9 @@
+# same as requirements.txt
+# (not using -r because this will be used in setup.py)
+setuptools
+more-executors>=2.3.0
+requests
+requests-kerberos
+
+# backport of concurrent.futures for Python 2.x.
+futures

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,3 @@ setuptools
 more-executors>=2.3.0
 requests
 requests-kerberos
-
-# backport of concurrent.futures for Python 2.x.
-# do NOT install this under Python 3.x.
-futures; python_version < "3"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 """setup.py"""
 
 import os
+import sys
 
 # import pkg_resources
 import sys
@@ -52,7 +53,12 @@ classifiers = [
 
 
 def get_requirements():
-    with open("requirements.txt") as f:
+    if sys.version_info[0] == 2:
+        filename = "requirements-py26.txt"
+    else:
+        filename = "requirements.txt"
+
+    with open(filename) as f:
         return f.read().splitlines()
 
 


### PR DESCRIPTION
A recent change to the requirements file (#24) has passed a check in CI but the build failed in a pure Py2.6 environment.  The cause is probably the lack of support for environment markers in requirement specifiers in older distutils.  The reason why it passed CI is probably due to Py2.7 being used to install dependencies for Py2.6.  This PR replaces the line with unsupported syntax with a separate file for ancient pythons.