### PR TITLE
Tolerate 409 of signature upload

### DIFF
--- a/pubtools/_pyxis/pyxis_client.py
+++ b/pubtools/_pyxis/pyxis_client.py
@@ -202,6 +202,10 @@ class PyxisClient(object):
         except ValueError:  # Python 2.x compat
             data = {}
 
+        # Uploaded data already exists in Pyxis
+        if response.status_code == 409:
+            return data
+
         try:
             response.raise_for_status()
         except HTTPError as e:


### PR DESCRIPTION
Uploading a signature could get 409 if it already exists in Pyxis. It could be caused by a parallel push of the same image or retrying a failed upload request which created signature although it got an error response. Don't fail upload when Pyxis returns 409.

Refers to CLOUDDST-15646