### PR TITLE
Pin bandit version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ requests-mock
 pytest
 pytest-pylint
 pytest-cov
+bandit==1.7.5

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
 
 [testenv:py3-bandit]
 deps=
-    bandit
+    -rrequirements-test.txt
 commands=
     bandit -r . -ll --exclude './.tox'
 


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to tox.ini.