### PR TITLE
Add mypy checks to pubtools-pyxis

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,7 +3,7 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py37:
+  py310:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,11 +14,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py37 -vv
+        run: tox -e py310 -vv
   black:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -62,11 +62,27 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
         run: tox -e docs -vv
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update existing dependencies
+        run: sudo apt-get update -y
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e mypy -vv
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -78,11 +94,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py37
+        run: tox -e py310
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
@@ -99,7 +115,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+strict = True

--- a/pubtools/_pyxis/pyxis_authentication.py
+++ b/pubtools/_pyxis/pyxis_authentication.py
@@ -3,15 +3,17 @@ import subprocess
 
 from requests_kerberos import HTTPKerberosAuth, OPTIONAL
 
+from .pyxis_session import PyxisSession
 
-class PyxisAuth(object):
+
+class PyxisAuth:
     """Base Auth class."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize."""
         raise NotImplementedError  # pragma: no cover"
 
-    def apply_to_session(self, pyxis_session):
+    def apply_to_session(self, pyxis_session: PyxisSession) -> None:
         """Set up initialization in the Pyxis session."""
         raise NotImplementedError  # pragma: no cover"
 
@@ -20,7 +22,7 @@ class PyxisSSLAuth(PyxisAuth):
     """SSL Auth provider to PyxisClient."""
 
     # pylint: disable=super-init-not-called
-    def __init__(self, crt_path, key_path):
+    def __init__(self, crt_path: str, key_path: str) -> None:
         """
         Initialize.
 
@@ -33,7 +35,7 @@ class PyxisSSLAuth(PyxisAuth):
         self.crt_path = crt_path
         self.key_path = key_path
 
-    def apply_to_session(self, pyxis_session):
+    def apply_to_session(self, pyxis_session: PyxisSession) -> None:
         """
         Set up PyxisSession with SSL auth.
 
@@ -47,7 +49,9 @@ class PyxisSSLAuth(PyxisAuth):
 class PyxisKrbAuth(PyxisAuth):
     """Kerberos authentication support for PyxisClient."""
 
-    def __init__(self, krb_princ, service, ktfile=None, ccache_file=None):
+    def __init__(
+        self, krb_princ: str, service: str, ccache_file: str, ktfile: str | None = None
+    ) -> None:
         """
         Initialize.
 
@@ -56,17 +60,17 @@ class PyxisKrbAuth(PyxisAuth):
                 Kerberos principal for obtaining ticket.
             service (str)
                 URL of the service to apply the authentication to.
-            ktfile (str)
-                Kerberos client keytab file.
             ccache_file (str)
                 Path to a file used for ccache. Only necessary if kinit will be used.
+            ktfile (str)
+                Kerberos client keytab file.
         """
         self.krb_princ = krb_princ
         self.service = service
         self.ktfile = ktfile
         self.ccache_file = ccache_file
 
-    def _krb_auth(self):
+    def _krb_auth(self) -> HTTPKerberosAuth:
         retcode = subprocess.Popen(
             ["klist", "-s"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).wait()
@@ -102,7 +106,7 @@ class PyxisKrbAuth(PyxisAuth):
             force_preemptive=True,
         )
 
-    def apply_to_session(self, pyxis_session):
+    def apply_to_session(self, pyxis_session: PyxisSession) -> None:
         """Set up PyxisSession with Kerberos auth.
 
         Args:

--- a/pubtools/_pyxis/pyxis_ops.py
+++ b/pubtools/_pyxis/pyxis_ops.py
@@ -1,9 +1,11 @@
 import json
 import sys
 import tempfile
+from argparse import ArgumentParser, Namespace
+from typing import Any
 
 from .constants import DEFAULT_REQUEST_THREADS_LIMIT
-from .pyxis_authentication import PyxisKrbAuth, PyxisSSLAuth
+from .pyxis_authentication import PyxisKrbAuth, PyxisSSLAuth, PyxisAuth
 from .pyxis_client import PyxisClient
 from .utils import setup_arg_parser
 
@@ -116,7 +118,7 @@ DELETE_SIGNATURES_ARGS[("--request-threads",)] = {
 }
 
 
-def setup_pyxis_client(args, ccache_file):
+def setup_pyxis_client(args: Namespace, ccache_file: str) -> PyxisClient:
     """
     Set up a PyxisClient instance according to specified parameters.
 
@@ -131,11 +133,11 @@ def setup_pyxis_client(args, ccache_file):
     """
     # If both auths are specified, Kerberos is preferred
     if args.pyxis_krb_principal:
-        auth = PyxisKrbAuth(
+        auth: PyxisAuth = PyxisKrbAuth(
             args.pyxis_krb_principal,
             args.pyxis_server,
-            args.pyxis_krb_ktfile,
             ccache_file,
+            args.pyxis_krb_ktfile,
         )
     elif args.pyxis_ssl_crtfile and args.pyxis_ssl_keyfile:
         auth = PyxisSSLAuth(args.pyxis_ssl_crtfile, args.pyxis_ssl_keyfile)
@@ -156,12 +158,12 @@ def setup_pyxis_client(args, ccache_file):
         return PyxisClient(args.pyxis_server, auth=auth, verify=not args.pyxis_insecure)
 
 
-def set_get_operator_indices_args():
+def set_get_operator_indices_args() -> ArgumentParser:
     """Set up argparser without extra parameters, this method is used for auto doc generation."""
     return setup_arg_parser(GET_OPERATORS_INDICES_ARGS)
 
 
-def get_operator_indices_main(sysargs=None):
+def get_operator_indices_main(sysargs: list[str] | None = None) -> list[str] | Any:
     """
     Entrypoint for getting operator indices.
 
@@ -184,12 +186,12 @@ def get_operator_indices_main(sysargs=None):
         return resp
 
 
-def set_get_repo_metadata_args():
+def set_get_repo_metadata_args() -> ArgumentParser:
     """Set up argparser without extra parameters, this method is used for auto doc generation."""
     return setup_arg_parser(GET_REPO_METADATA_ARGS)
 
 
-def get_repo_metadata_main(sysargs=None):
+def get_repo_metadata_main(sysargs: list[str] | None = None) -> dict[Any, Any] | Any:
     """
     Entrypoint for getting repository metadata.
 
@@ -221,12 +223,12 @@ def get_repo_metadata_main(sysargs=None):
         return res
 
 
-def set_upload_signatures_args():
+def set_upload_signatures_args() -> ArgumentParser:
     """Set up argparser without extra parameters, this method is used for auto doc generation."""
     return setup_arg_parser(UPLOAD_SIGNATURES_ARGS)
 
 
-def upload_signatures_main(sysargs=None):
+def upload_signatures_main(sysargs: list[str] | None = None) -> list[Any]:
     """
     Entrypoint for uploading signatures from JSON or a file.
 
@@ -250,7 +252,7 @@ def upload_signatures_main(sysargs=None):
         return resp
 
 
-def deserialize_list_from_arg(value, csv_input=False):
+def deserialize_list_from_arg(value: str, csv_input: bool = False) -> list[Any] | Any:
     """
     Conditionally load contents of a file if specified in argument value.
 
@@ -275,17 +277,17 @@ def deserialize_list_from_arg(value, csv_input=False):
         return json.load(f)
 
 
-def serialize_to_csv_from_list(list_value):
+def serialize_to_csv_from_list(list_value: list[Any]) -> str:
     """Convert a list to comma separated string."""
     return ",".join(list_value)
 
 
-def set_get_signatures_args():
+def set_get_signatures_args() -> ArgumentParser:
     """Set up argparser without extra parameters, this method is used for auto doc generation."""
     return setup_arg_parser(GET_SIGNATURES_ARGS)
 
 
-def get_signatures_main(sysargs=None):
+def get_signatures_main(sysargs: list[str] | None = None) -> list[str]:
     """
     Entrypoint for getting container signature metadata.
 
@@ -320,12 +322,12 @@ def get_signatures_main(sysargs=None):
         return res
 
 
-def set_delete_signatures_args():
+def set_delete_signatures_args() -> ArgumentParser:
     """Set up argparser without extra parameters, this method is used for auto doc generation."""
     return setup_arg_parser(DELETE_SIGNATURES_ARGS)
 
 
-def delete_signatures_main(sysargs=None):
+def delete_signatures_main(sysargs: list[str] | None = None) -> None:
     """
     Entrypoint for removing existing signatures.
 

--- a/pubtools/_pyxis/pyxis_session.py
+++ b/pubtools/_pyxis/pyxis_session.py
@@ -1,13 +1,20 @@
+from typing import Any
+
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 
-# pylint: disable=bad-option-value,useless-object-inheritance
-class PyxisSession(object):
+class PyxisSession:
     """Helper class to support Pyxis requests and authentication."""
 
-    def __init__(self, hostname, retries=5, backoff_factor=5, verify=False):
+    def __init__(
+        self,
+        hostname: str,
+        retries: int = 5,
+        backoff_factor: int = 5,
+        verify: bool = False,
+    ) -> None:
         """
         Initialize.
 
@@ -47,7 +54,7 @@ class PyxisSession(object):
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
 
-    def get(self, endpoint, **kwargs):
+    def get(self, endpoint: str, **kwargs: Any) -> requests.Response:
         """
         HTTP GET request against Pyxis server API.
 
@@ -59,7 +66,7 @@ class PyxisSession(object):
         """
         return self.session.get(self._api_url(endpoint), **kwargs)
 
-    def post(self, endpoint, **kwargs):
+    def post(self, endpoint: str, **kwargs: Any) -> requests.Response:
         """
         HTTP POST request against Pyxis server API.
 
@@ -71,7 +78,7 @@ class PyxisSession(object):
         """
         return self.session.post(self._api_url(endpoint), **kwargs)
 
-    def put(self, endpoint, **kwargs):
+    def put(self, endpoint: str, **kwargs: Any) -> requests.Response:
         """
         HTTP PUT request against Pyxis server API.
 
@@ -83,7 +90,7 @@ class PyxisSession(object):
         """
         return self.session.put(self._api_url(endpoint), **kwargs)
 
-    def delete(self, endpoint, **kwargs):
+    def delete(self, endpoint: str, **kwargs: Any) -> requests.Response:
         """
         HTTP DELETE request against Pyxis server API.
 
@@ -95,7 +102,7 @@ class PyxisSession(object):
         """
         return self.session.delete(self._api_url(endpoint), **kwargs)
 
-    def _api_url(self, endpoint):
+    def _api_url(self, endpoint: str) -> str:
         """
         Generate full url of the API endpoint.
 
@@ -110,6 +117,6 @@ class PyxisSession(object):
         else:
             return "%s/v1/%s" % (self.hostname.rstrip("/"), endpoint)
 
-    def close(self):
+    def close(self) -> None:
         """Close the current session."""
         self.session.close()

--- a/pubtools/_pyxis/utils.py
+++ b/pubtools/_pyxis/utils.py
@@ -1,7 +1,8 @@
 import argparse
+from typing import Any
 
 
-def setup_arg_parser(args):
+def setup_arg_parser(args: dict[Any, Any]) -> argparse.ArgumentParser:
     """
     Set up ArgumentParser with the provided arguments.
 
@@ -12,7 +13,7 @@ def setup_arg_parser(args):
         (ArgumentParser) Configured instance of ArgumentParser.
     """
     parser = argparse.ArgumentParser()
-    arg_groups = {}
+    arg_groups: dict[Any, Any] = {}
     for aliases, arg_data in args.items():
         holder = parser
         if "group" in arg_data:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,5 @@ pytest
 pytest-pylint
 pytest-cov
 bandit==1.7.5
+mypy
+types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ setuptools
 more-executors>=2.3.0
 requests
 requests-kerberos
+urllib3<2

--- a/tests/test_pyxis_authentication.py
+++ b/tests/test_pyxis_authentication.py
@@ -24,7 +24,7 @@ def test_krb_auth_init(hostname):
     service = hostname
     ktfile = "/root/file.keytab"
 
-    krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, ktfile)
+    krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, "/path", ktfile)
     assert krb_auth.krb_princ == krb_princ
     assert krb_auth.service == service
     assert krb_auth.ktfile == ktfile
@@ -39,7 +39,7 @@ def test_krb_auth_use_keytab(mock_popen, hostname):
 
     with tempfile.NamedTemporaryFile() as tmpfile:
         krb_auth = pyxis_authentication.PyxisKrbAuth(
-            krb_princ, service, ktfile, tmpfile.name
+            krb_princ, service, tmpfile.name, ktfile
         )
         mock_wait = mock.MagicMock()
         mock_wait.side_effect = [0, 0, 0]
@@ -99,7 +99,7 @@ def test_krb_auth_skip_init(mock_popen, hostname):
     krb_princ = "name@REDHAT.COM"
     service = hostname
 
-    krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service)
+    krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, "/path")
     mock_wait = mock.MagicMock()
     mock_wait.return_value = 0
     mock_popen.return_value.wait = mock_wait
@@ -118,7 +118,7 @@ def test_krb_apply_to_session(mock_krb_auth, hostname):
     service = hostname
     ktfile = "/root/file.keytab"
 
-    krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, ktfile)
+    krb_auth = pyxis_authentication.PyxisKrbAuth(krb_princ, service, ktfile, "/path")
     my_pyxis_session = pyxis_session.PyxisSession(hostname)
     krb_auth.apply_to_session(my_pyxis_session)
     assert isinstance(my_pyxis_session.session.auth, mock.MagicMock)

--- a/tests/test_pyxis_client.py
+++ b/tests/test_pyxis_client.py
@@ -215,12 +215,14 @@ def test_delete_container_signatures_success(hostname):
         my_client = pyxis_client.PyxisClient(hostname, 5, None, 3, True)
         my_client.delete_container_signatures(ids)
         assert len(m.request_history) == 2
-        assert m.request_history[0].url == urljoin(
-            hostname, "/v1/signatures/id/g1g1g1g1"
+        observed_urls = sorted([h.url for h in m.request_history])
+        expected_urls = sorted(
+            [
+                urljoin(hostname, "/v1/signatures/id/g1g1g1g1"),
+                urljoin(hostname, "/v1/signatures/id/h2h2h2h2"),
+            ]
         )
-        assert m.request_history[1].url == urljoin(
-            hostname, "/v1/signatures/id/h2h2h2h2"
-        )
+        assert observed_urls == expected_urls
 
 
 def test_delete_container_signatures_tolerate_404(hostname):
@@ -233,12 +235,14 @@ def test_delete_container_signatures_tolerate_404(hostname):
         my_client = pyxis_client.PyxisClient(hostname, 5, None, 3, True)
         my_client.delete_container_signatures(ids)
         assert len(m.request_history) == 2
-        assert m.request_history[0].url == urljoin(
-            hostname, "/v1/signatures/id/g1g1g1g1"
+        observed_urls = sorted([h.url for h in m.request_history])
+        expected_urls = sorted(
+            [
+                urljoin(hostname, "/v1/signatures/id/g1g1g1g1"),
+                urljoin(hostname, "/v1/signatures/id/h2h2h2h2"),
+            ]
         )
-        assert m.request_history[1].url == urljoin(
-            hostname, "/v1/signatures/id/h2h2h2h2"
-        )
+        assert observed_urls == expected_urls
 
 
 def test_delete_container_signatures_server_error(hostname):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,black,flake8,docs,py3-bandit
+envlist = py310,black,flake8,docs,mypy,py3-bandit
 skip_missing_interpreters = true
 
 [testenv]
@@ -24,7 +24,7 @@ deps=
     Sphinx
     sphinx_rtd_theme
     sphinx-argparse
-commands = python setup.py build_sphinx
+commands = sphinx-build -M html docs/source docs/build
 
 [testenv:flake8]
 description = PEP8 checks
@@ -34,6 +34,15 @@ deps =
     flake8-docstrings
 commands =
     flake8 pubtools tests
+
+[testenv:mypy]
+description = mypy checks
+basepython = python3
+deps =
+    -rrequirements-test.txt
+    -rrequirements.txt
+commands =
+    mypy pubtools
 
 [testenv:py3-bandit]
 deps=


### PR DESCRIPTION
The mypy checks pass in the strict mode. Some functions may return "Any", which is due to the fact that methods of the "requests" library may return unusual types (for example json() mat return None). __init__ method of the PyxisKrbAuth class had to be slightly rewritten so that its argument only contained supported values.

Refers to CLOUDDST-20547