### PR TITLE
fix(RELEASE-2180): unpin unsafe urllib3 version

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,7 +3,7 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py310:
+  py311:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,11 +14,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py310 -vv
+        run: tox -e py311 -vv
   black:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -94,11 +94,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py310
+        run: tox -e py311
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:
@@ -117,7 +117,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,6 @@ requests-mock
 pytest
 pytest-pylint
 pytest-cov
-bandit==1.7.5
+bandit
 mypy
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ setuptools
 more-executors>=2.3.0
 requests
 requests-kerberos
-urllib3<2

--- a/src/pubtools/_pyxis/pyxis_ops.py
+++ b/src/pubtools/_pyxis/pyxis_ops.py
@@ -9,7 +9,6 @@ from .pyxis_authentication import PyxisKrbAuth, PyxisSSLAuth, PyxisAuth
 from .pyxis_client import PyxisClient
 from .utils import setup_arg_parser
 
-
 CMD_ARGS = {
     ("--pyxis-server",): {
         "help": "Pyxis service hostname",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,black,flake8,docs,mypy,py3-bandit
+envlist = py311,py314,black,flake8,docs,mypy,py3-bandit
 skip_missing_interpreters = true
 
 [testenv]
@@ -13,7 +13,7 @@ whitelist_externals=sh
 
 [testenv:black]
 description = black checks
-basepython = python3
+basepython = python311
 deps =
     black
 commands =
@@ -28,7 +28,7 @@ commands = sphinx-build -M html docs/source docs/build
 
 [testenv:flake8]
 description = PEP8 checks
-basepython = python3
+basepython = python311
 deps =
     flake8
     flake8-docstrings
@@ -37,7 +37,7 @@ commands =
 
 [testenv:mypy]
 description = mypy checks
-basepython = python39
+basepython = python311
 deps =
     -rrequirements-test.txt
     -rrequirements.txt
@@ -45,6 +45,7 @@ commands =
     mypy src/pubtools
 
 [testenv:py3-bandit]
+basepython = python311
 deps=
     -rrequirements-test.txt
 commands=


### PR DESCRIPTION
Pinning urllib3 to version <2 forces all services that use pubtools-pyxis to use an old, vulnerable version of this library. This commit removes the version pinning. The most likely reason why it was pinned previously was to ensure that the mypy checks would pass. However, this doesn't seem necessary with the newer versions of urllib3.

Few other minor changes were made to ensure that CI passes:
- whitespace removal suggested by black
- unpinning bandit version (the test didn't run with the pinned version)
- changing tested Python versions to 3.11 and 3.14 since these ones are actually used